### PR TITLE
Fix issue #1 sample length of SndFileIO::read_all_to_vec()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,7 +535,7 @@ impl SndFileIO<i16> for SndFile {
   }
 
   fn read_all_to_vec(&mut self) -> Result<Vec<i16>, ()> {
-    let n = self.len()? as usize;
+    let n = self.len()? as usize * self.channels;
     self.seek(SeekFrom::Start(0))?;
     let mut buf = vec![0; n];
     self.read_to_slice(&mut buf).map(|_| buf)
@@ -580,7 +580,7 @@ impl SndFileIO<i32> for SndFile {
   }
 
   fn read_all_to_vec(&mut self) -> Result<Vec<i32>, ()> {
-    let n = self.len()? as usize;
+    let n = self.len()? as usize * self.channels;
     self.seek(SeekFrom::Start(0))?;
     let mut buf = vec![0; n];
     self.read_to_slice(&mut buf).map(|_| buf)
@@ -625,7 +625,7 @@ impl SndFileIO<f32> for SndFile {
   }
 
   fn read_all_to_vec(&mut self) -> Result<Vec<f32>, ()> {
-    let n = self.len()? as usize;
+    let n = self.len()? as usize * self.channels;
     self.seek(SeekFrom::Start(0))?;
     let mut buf = vec![0.0; n];
     self.read_to_slice(&mut buf).map(|_| buf)
@@ -670,7 +670,7 @@ impl SndFileIO<f64> for SndFile {
   }
 
   fn read_all_to_vec(&mut self) -> Result<Vec<f64>, ()> {
-    let n = self.len()? as usize;
+    let n = self.len()? as usize * self.channels;
     self.seek(SeekFrom::Start(0))?;
     let mut buf = vec![0.0; n];
     self.read_to_slice(&mut buf).map(|_| buf)


### PR DESCRIPTION
Fix for #1. The `buf` Vec in the `read_all_to_vec()` methods is now allocated with the correct length.
