### PR TITLE
Fixed get_tag, added an Option wrapping to deal with missing tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ fn main() {
   let samplerate = snd.get_samplerate();
   let n_frame = snd.len().unwrap();
   let n_channels = snd.get_channels();
-  let title = snd.get_tag(TagType::Title);
+  let title = snd.get_tag(TagType::Title).unwrap();
   println!("Loaded song `{}`:", title);
   println!("  Length: {:.2} seconds", n_frame as f64 / samplerate as f64);
   println!("  Sample rate: {} Hz", samplerate);

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use tempfile::TempDir;
 mod test_issue_1;
+mod test_issue_3;
 
 #[test]
 fn supported_format() {
@@ -79,7 +80,7 @@ fn file_io_ok_0() {
     for chunk in buf.chunks(DESIRED_BUF.len()) {
       assert_eq!(chunk[..], DESIRED_BUF[..]);
     }
-    assert_eq!(snd.get_tag(TagType::Title), TAG_STR);
+    assert_eq!(snd.get_tag(TagType::Title).unwrap(), TAG_STR);
   }
   std::fs::remove_file(&tmp_path).unwrap();
 }

--- a/src/test/test_issue_3.rs
+++ b/src/test/test_issue_3.rs
@@ -1,0 +1,80 @@
+use crate::*;
+use tempfile::TempDir;
+
+#[test]
+fn issue_3_no_tags() {
+  // ch = 1, t = 50ms, sr = 2000Hz, tone = sin 880Hz
+  static DATA: &'static [u8] = b"RIFF\x88\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00\xd0\x07\x00\x00\xd0\x07\x00\x00\x01\x00\x08\x00datad\x00\x00\x00\x80\xa59\xdc\x19\xe11\xb1sf\xbc)\xe4\x1b\xd6C\x99\x8cN\xce\x1e\xe6#\xc6Z\x80\xa59\xdc\x19\xe11\xb1sf\xbc)\xe4\x1b\xd6C\x99\x8cN\xce\x1e\xe6#\xc6Z\x7f\xa59\xdc\x19\xe11\xb1sf\xbc)\xe4\x1b\xd6C\x99\x8cN\xce\x1e\xe6#\xc6Z\x7f\xa59\xdc\x19\xe11\xb1sf\xbc)\xe4\x1b\xd6C\x99\x8cN\xce\x1e\xe6#\xc6Z";
+  let tmp_dir = TempDir::new().unwrap();
+  let tmp_path = tmp_dir.as_ref().join("issue_3_no_tags.wav");
+  std::fs::write(&tmp_path, DATA).unwrap();
+
+  let mut snd = OpenOptions::ReadOnly(ReadOptions::Auto).from_path(&tmp_path).unwrap();
+  
+  // Empty header, should not have any tag set
+  assert_eq!(snd.get_tag(TagType::Title), None);
+  assert_eq!(snd.get_tag(TagType::Copyright), None);
+  assert_eq!(snd.get_tag(TagType::Software), None);
+  assert_eq!(snd.get_tag(TagType::Artist), None);
+  assert_eq!(snd.get_tag(TagType::Comment), None);
+  assert_eq!(snd.get_tag(TagType::Date), None);
+  assert_eq!(snd.get_tag(TagType::Album), None);
+  assert_eq!(snd.get_tag(TagType::License), None);
+  assert_eq!(snd.get_tag(TagType::Tracknumber), None);
+  assert_eq!(snd.get_tag(TagType::Genre), None);
+}
+
+#[test]
+fn issue_3_some_tags() {
+  // Tags to set
+  const TAG_TITLE_STR: &str = "some_title";
+  const TAG_COPYRIGHT: &str = "dobby_is_free";
+  const TAG_COMMENT: &str = "no comment";
+
+  // Empty data vec
+  const DEFAULT_BUF: [i16; 256] = [0i16; 256];
+
+  let tmp_dir = TempDir::new().unwrap();
+  let tmp_path = tmp_dir.as_ref().join("issue_3_some_tags.wav");
+
+  // Write the file
+  {
+    let mut snd = OpenOptions::WriteOnly(WriteOptions::new(
+      MajorFormat::WAV,
+      SubtypeFormat::PCM_24,
+      Endian::File,
+      8000,
+      2,
+    ))
+    .from_path(&tmp_path)
+    .unwrap();
+    for _ in 0..256 {
+      snd.write_from_slice(&DEFAULT_BUF).unwrap();
+    }
+    snd.set_tag(TagType::Title, TAG_TITLE_STR).unwrap();
+    snd.set_tag(TagType::Copyright, TAG_COPYRIGHT).unwrap();
+    snd.set_tag(TagType::Comment, TAG_COMMENT).unwrap();
+  }
+
+  // Check the file
+  {
+    let mut snd = OpenOptions::ReadOnly(ReadOptions::Auto)
+      .from_path(&tmp_path)
+      .unwrap();
+    
+    // Check the tags has been set
+    assert_eq!(snd.get_tag(TagType::Title).unwrap(), TAG_TITLE_STR);
+    assert_eq!(snd.get_tag(TagType::Copyright).unwrap(), TAG_COPYRIGHT);
+    assert_eq!(snd.get_tag(TagType::Comment).unwrap(), TAG_COMMENT);
+
+    // Check the missing tags returns None
+    assert_eq!(snd.get_tag(TagType::Software), None);
+    assert_eq!(snd.get_tag(TagType::Artist), None);
+    assert_eq!(snd.get_tag(TagType::Date), None);
+    assert_eq!(snd.get_tag(TagType::Album), None);
+    assert_eq!(snd.get_tag(TagType::License), None);
+    assert_eq!(snd.get_tag(TagType::Tracknumber), None);
+    assert_eq!(snd.get_tag(TagType::Genre), None);
+  }
+  std::fs::remove_file(&tmp_path).unwrap();
+}


### PR DESCRIPTION
Close #3

A fix proposal to fix issue #3, I added an `Option` wrapping to `get_tag` return. 

Explanation : 
As mentioned in the the thread, libsndfile will return a `NULL` pointer if the asked tag does not exists, which cause a segfault. This fix deals with the `NULL` ptr by return a None

As I understand it is a little breaking change tell me if you'd rather return an empty string as mentioned in the issue thread, it could be done too, even though it might not be the most idiomatic.