### PR TITLE
Prevent unused warnings by dropping Box::from_raw

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,8 +415,8 @@ impl OpenOptions {
       };
       if sndfile_ptr.is_null() {
         unsafe {
-          Box::from_raw(vio_user_ptr);
-          Box::from_raw(vio_ptr);
+          drop(Box::from_raw(vio_user_ptr));
+          drop(Box::from_raw(vio_ptr));
         }
         Err(sf_err_code_to_enum(unsafe {
           sndfile_sys::sf_error(sndfile_ptr)
@@ -485,8 +485,8 @@ impl Drop for UnsafeSndFile {
   fn drop(&mut self) {
     let err_code = unsafe { sndfile_sys::sf_close(self.sndfile_ptr) };
     unsafe {
-      Box::from_raw(self.vio_user_ptr);
-      Box::from_raw(self.vio_ptr);
+      drop(Box::from_raw(self.vio_user_ptr));
+      drop(Box::from_raw(self.vio_ptr));
     }
     if err_code != 0 {
       let err_msg = unsafe {


### PR DESCRIPTION
Using `Box::from_raw()` and ignoring the return value produces a warning:

```
warning: unused return value of `Box::<T>::from_raw` that must be used                                                                                                                          
   --> src/lib.rs:418:11                                                                                                                                                                        
    |                                                                                                                                                                                           
418 |           Box::from_raw(vio_user_ptr);                                                                                                                                                    
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                     
    |                                                                                                                                                                                           
    = note: call `drop(Box::from_raw(ptr))` if you intend to drop the `Box`
```

This PR fixes that by wrapping it with a `drop()`